### PR TITLE
Nft auction attribute isRepeated is now correctly read from chain.

### DIFF
--- a/src/contract-logic/queries/getAuctions.ts
+++ b/src/contract-logic/queries/getAuctions.ts
@@ -159,7 +159,7 @@ export async function getAuction(connection: Connection, id: string, n?: number)
       name: masterMetadata.name,
       symbol: masterMetadata.symbol,
       uri: masterMetadata.uri,
-      isRepeated: false,
+      isRepeated: !!auctionRootStateDeserialized.tokenConfig.tokenConfigNft.unnamed.isRepeating,
     }
   } else if (auctionRootStateDeserialized.tokenConfig.tokenConfigToken) {
     const mintPubkey = auctionRootStateDeserialized.tokenConfig.tokenConfigToken.unnamed.mint


### PR DESCRIPTION
## Description
For some reason in the `getAuction` query, the nft auction attribute `isRepeated` was not read from the state. Now its fixed.