### PR TITLE
Contract error handling

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,4 @@
 const withTM = require("next-transpile-modules")([
-  "@blocto/sdk",
   "@project-serum/sol-wallet-adapter",
   "@solana/wallet-adapter-base",
   "@solana/wallet-adapter-react",
@@ -31,6 +30,7 @@ module.exports = withTM({
         new WasmPackPlugin({
           crateDirectory: resolve("./rust/client"),
           args: "--log-level warn",
+          extraArgs: `--features ${process.env.NEXT_PUBLIC_NETWORK}`,
           outDir: "../../src/contract-logic/wasm-factory",
           outName: "instructions",
         })

--- a/src/components/[auction]/PlaceBid/hook/usePlaceBid.ts
+++ b/src/components/[auction]/PlaceBid/hook/usePlaceBid.ts
@@ -4,6 +4,7 @@ import useCycle from "components/[auction]/hooks/useCycle"
 import { placeBid } from "contract-logic/transactions/placeBid"
 import useSubmit from "hooks/useSubmit"
 import useToast from "hooks/useToast"
+import processContractError from "utils/processContractErrorr"
 
 type Data = {
   // string as it comes from the form
@@ -11,7 +12,7 @@ type Data = {
 }
 
 const usePlaceBid = (setValue) => {
-  const toast = useToast()
+  const toast = useToast({ status: "error" })
   const { connection } = useConnection()
   const { sendTransaction, publicKey } = useWallet()
   const { auction, mutate: mutateAuction } = useAuction()
@@ -32,11 +33,7 @@ const usePlaceBid = (setValue) => {
   }
 
   return useSubmit<Data, any>(handlePlaceBid, {
-    onError: () =>
-      toast({
-        title: "Error placing bid",
-        status: "error",
-      }),
+    onError: (e) => toast(processContractError(e)),
     onSuccess: () => {
       toast({
         title: "Bid placed successfully",

--- a/src/components/[auction]/SettingsMenu/components/ClaimDialog.tsx
+++ b/src/components/[auction]/SettingsMenu/components/ClaimDialog.tsx
@@ -13,12 +13,13 @@ import { claimFunds } from "contract-logic/transactions/claimFunds"
 import useSubmit from "hooks/useSubmit"
 import useToast from "hooks/useToast"
 import { useRef } from "react"
+import processContractError from "utils/processContractErrorr"
 
 const ClaimDialog = ({ isOpen, onClose }) => {
   const { auction, mutate } = useAuction()
   const { connection } = useConnection()
   const { sendTransaction } = useWallet()
-  const toast = useToast()
+  const toast = useToast({ status: "error" })
   const alertCancelRef = useRef()
 
   const handleClaimFunds = async () => {
@@ -47,12 +48,7 @@ const ClaimDialog = ({ isOpen, onClose }) => {
       mutate()
       onClose()
     },
-    onError: (e) =>
-      toast({
-        title: "Error claiming funds",
-        description: e.toString(),
-        status: "error",
-      }),
+    onError: (e) => toast(processContractError(e)),
   })
 
   return (

--- a/src/components/[auction]/SettingsMenu/components/DeleteDialog.tsx
+++ b/src/components/[auction]/SettingsMenu/components/DeleteDialog.tsx
@@ -15,13 +15,14 @@ import useToast from "hooks/useToast"
 import { useRouter } from "next/router"
 import { useRef } from "react"
 import { useSWRConfig } from "swr"
+import processContractError from "utils/processContractErrorr"
 
 export default function DeleteDialog({ isOpen, onClose }) {
   const { mutate } = useSWRConfig()
   const { auction } = useAuction()
   const { connection } = useConnection()
   const { sendTransaction } = useWallet()
-  const toast = useToast()
+  const toast = useToast({ status: "error" })
   const router = useRouter()
   const alertCancelRef = useRef()
 
@@ -49,12 +50,7 @@ export default function DeleteDialog({ isOpen, onClose }) {
       )
       router.push("/")
     },
-    onError: (e) =>
-      toast({
-        title: "Error deleting auction",
-        description: e.toString(),
-        status: "error",
-      }),
+    onError: (e) => toast(processContractError(e)),
   })
 
   return (

--- a/src/components/create-auction/hooks/useStartAuction.ts
+++ b/src/components/create-auction/hooks/useStartAuction.ts
@@ -7,6 +7,7 @@ import { useRouter } from "next/router"
 import { useState } from "react"
 import { useSWRConfig } from "swr"
 import pinFileToIpfs from "utils/pinataUpload"
+import processContractError from "utils/processContractErrorr"
 
 const HOUR_IN_SECONDS = 3600
 
@@ -28,7 +29,7 @@ export type FormData = {
 
 const useStartAuction = () => {
   const [data, setData] = useState<AuctionConfig>()
-  const toast = useToast()
+  const toast = useToast({ status: "error" })
   const { connection } = useConnection()
   const { mutate } = useSWRConfig()
   const router = useRouter()
@@ -60,12 +61,9 @@ const useStartAuction = () => {
         mutate("auctions")
         router.push(`/${data.id}`)
       },
-      onError: (e) =>
-        toast({
-          title: "Error creating auction",
-          description: e.toString(),
-          status: "error",
-        }),
+      onError: (e) => {
+        toast(processContractError(e))
+      },
     }
   )
 

--- a/src/components/create-auction/hooks/useStartAuction.ts
+++ b/src/components/create-auction/hooks/useStartAuction.ts
@@ -61,9 +61,7 @@ const useStartAuction = () => {
         mutate("auctions")
         router.push(`/${data.id}`)
       },
-      onError: (e) => {
-        toast(processContractError(e))
-      },
+      onError: (e) => toast(processContractError(e)),
     }
   )
 

--- a/src/utils/processContractErrorr.ts
+++ b/src/utils/processContractErrorr.ts
@@ -1,0 +1,136 @@
+const EXTRACT_ERROR_CODE_REGEX = /custom program error: 0x([0-9a-f]{3})/i
+
+const processContractError = (
+  error: string
+): { title: string; description: string } => {
+  const errorCode = error.match(EXTRACT_ERROR_CODE_REGEX)?.[1]?.toLowerCase()
+
+  switch (errorCode) {
+    case "1f5":
+      return {
+        title: "Auction cycle ended",
+        description: "This auction cycle has ended",
+      }
+
+    case "1f6":
+      return {
+        title: "Auction frozen",
+        description: "This auction is frozen",
+      }
+
+    case "1f9":
+      return {
+        title: "Auction is in progress",
+        description: "",
+      }
+
+    case "20e":
+    case "1fb":
+      return {
+        title: "Invalid bid amount",
+        description: "Please adjust the bit amount to reach the dsipalyed minimum",
+      }
+
+    case "1fc":
+      return {
+        title: "Auction owner mismatch",
+        description: "Only the owner of this auction can execute this action",
+      }
+
+    case "1fd":
+      return {
+        title: "Invalid start time",
+        description: "The provided auction start date has already passed",
+      }
+
+    case "1ff": // Master edition mismatch
+    case "200": // Child edition number mismatch
+    case "201": // Nft already exists
+      return {
+        title: "NFT error",
+        description: "The submitted NFTs are invelid",
+      }
+
+    case "1f9":
+      return {
+        title: "Auction is in progress",
+        description: "",
+      }
+
+    case "202":
+      return {
+        title: "Invalid claim amount",
+        description: "Tried to claim an invalid amount of funds",
+      }
+
+    case "203":
+      return {
+        title: "Auction ended",
+        description: "This auction has already ended",
+      }
+
+    case "204":
+      return {
+        title: "Auction name taken",
+        description:
+          "This auction name is already taken. Please choose a different one",
+      }
+
+    case "205":
+      return {
+        title: "Not admin",
+        description: "Only contract admin can execute this action",
+      }
+
+    // Looks like this one does not get thrown anywhere
+    case "206":
+      return {
+        title: "Auction is active",
+        description: "This auction is active",
+      }
+
+    case "20a":
+      return {
+        title: "Arithmetic error",
+        description: "This is likely caudes by a bug. Please contact us",
+      }
+
+    case "210":
+      return {
+        title: "Invalid cycle period",
+        description:
+          "Make sure to set the cycle period correctly. If it looks fine, contact us",
+      }
+
+    case "211":
+      return {
+        title: "Auction ID not ASCII",
+        description: "This should not happen. Please contact us",
+      }
+
+    case "214": // Invalid encore period
+    case "213": // String too long -> This one does not seem to be thrown anywhere
+    case "212": // Token auction inconsistency
+    case "20f": // Invalid per cycle amount
+    case "20d": // Shrinking pool is not allowed
+    case "20c": // Auction pool full
+    case "20b": // Withdraw authority mismatch
+    case "209": // Invalid account owner
+    case "208": // Invalid program address
+    case "207": // Metadata manipulation error
+    case "1fe": // Top bidder account mismatch
+    case "1fa": // Invalid seeds
+    case "1f4": // Invalid instruction
+    case "1f7": // Auction already initialized
+    case "1f8": // Contract already initialized
+    default:
+      console.error("Unknown contract error:", error)
+      return {
+        title: "Contract error",
+        description:
+          "An unknown contract error occured. This is likely a bug in the application. Please check the console and contact us",
+      }
+  }
+}
+
+export default processContractError

--- a/src/utils/processContractErrorr.ts
+++ b/src/utils/processContractErrorr.ts
@@ -21,14 +21,14 @@ const processContractError = (
     case "1f9":
       return {
         title: "Auction is in progress",
-        description: "",
+        description: "This auction is in progress",
       }
 
     case "20e":
     case "1fb":
       return {
         title: "Invalid bid amount",
-        description: "Please adjust the bit amount to reach the dsipalyed minimum",
+        description: "Please adjust the bid amount to reach the dispalyed minimum",
       }
 
     case "1fc":
@@ -48,13 +48,7 @@ const processContractError = (
     case "201": // Nft already exists
       return {
         title: "NFT error",
-        description: "The submitted NFTs are invelid",
-      }
-
-    case "1f9":
-      return {
-        title: "Auction is in progress",
-        description: "",
+        description: "Some of the submitted NFTs are invalid",
       }
 
     case "202":
@@ -69,6 +63,7 @@ const processContractError = (
         description: "This auction has already ended",
       }
 
+    case "1f7":
     case "204":
       return {
         title: "Auction name taken",
@@ -79,7 +74,7 @@ const processContractError = (
     case "205":
       return {
         title: "Not admin",
-        description: "Only contract admin can execute this action",
+        description: "Only admin can execute this action",
       }
 
     // Looks like this one does not get thrown anywhere
@@ -92,20 +87,20 @@ const processContractError = (
     case "20a":
       return {
         title: "Arithmetic error",
-        description: "This is likely caudes by a bug. Please contact us",
+        description: "This is likely caused by a bug. Please contact us",
       }
 
     case "210":
       return {
         title: "Invalid cycle period",
-        description:
-          "Make sure to set the cycle period correctly. If it looks fine, contact us",
+        description: "Make sure to set the cycle period correctly",
       }
 
     case "211":
       return {
         title: "Auction ID not ASCII",
-        description: "This should not happen. Please contact us",
+        description:
+          "The id generated from the auction name contains invalid characters",
       }
 
     case "214": // Invalid encore period
@@ -121,7 +116,6 @@ const processContractError = (
     case "1fe": // Top bidder account mismatch
     case "1fa": // Invalid seeds
     case "1f4": // Invalid instruction
-    case "1f7": // Auction already initialized
     case "1f8": // Contract already initialized
     default:
       console.error("Unknown contract error:", error)


### PR DESCRIPTION
Closes #49 

Some of the errors didn't seem to be relevant for the contract calls, we are making, so I just listed them alongside the default branch of the switch, so we can quickly use them later if we need to.

Note: Thought about using the error handler a default for `useSubmit`, as right now, it is the same for every `useSubmit` call, but then it would have been tricky to make a hook call without an error handler if we needed to in the future, so decided to just leave it like this (it's only 4 calls so it's not that much of a big deal).